### PR TITLE
Make multishot not stealable

### DIFF
--- a/src/server/scripts/commands/skills/spells/thief/MultiShot.ts
+++ b/src/server/scripts/commands/skills/spells/thief/MultiShot.ts
@@ -19,6 +19,7 @@ export class MultiShot extends Skill {
 
   public name = ['multishot', 'cast multishot'];
   public format = 'Target';
+  public unableToLearnFromStealing = true;
 
   mpCost(user: Player) { return 0; }
 


### PR DESCRIPTION
I think I caused all of cata 5 to go braindead by imbuing this on a bow and proccing it; since multishot takes both hands, it doesn't make sense to have a scroll of it anyway